### PR TITLE
Fix moving website env file in Heroku build-pack

### DIFF
--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -1,4 +1,5 @@
-# This is buildpack-run.sh
+# Doing this temporarly b/c of system env variables missing
+mv .env.example .env
 # Remove package-lock as this is already done, Heroku can't decide at the node stage that yarn.local should be used instead.
 rm -rf package-lock.json
 # Installing the depedecies after PHP has been installed


### PR DESCRIPTION
Moving 
# Doing this temporarly b/c of system env variables missing
  mv .env.example .env
From avaire to website. As this makes more sense and also fixes this repo for heroku.